### PR TITLE
Added actual error stack with message

### DIFF
--- a/packages/sqs-partial-batch-failure/index.js
+++ b/packages/sqs-partial-batch-failure/index.js
@@ -87,7 +87,7 @@ const sqsPartialBatchFailureMiddleware = (opts = {}) => {
 
 const getRejectedReasons = (response) => {
   const rejected = response.filter((r) => r.status === 'rejected')
-  const rejectedReasons = rejected.map((r) => r.reason?.message)
+  const rejectedReasons = rejected.map((r) => `${r.reason?.message} ${r.reason?.stack}`)
 
   return rejectedReasons
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It passes Error Stack along with message.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Currently, if any worker gets shared by multiple methods, then it's very difficult (sometimes impossible without running locally) to pinpoint the exact location where the error occurs. Hence adding the original stack of the error.

Where has this been tested?
---------------------------
**Node.js Versions:** 14.17.6
**Middy Versions:** 2.5.3
**AWS SDK Versions:** ^2.1014.0


